### PR TITLE
Update GitHub Actions to run on main branch only

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,5 +1,8 @@
 name: update
-on: push
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   update:


### PR DESCRIPTION
The workflow configuration in .github/workflows/update.yml has been updated. Previously, it would run on every push event. Now, it will only run on push events that occur on the main branch.